### PR TITLE
clear write deadline after write to prevent connection state corruption

### DIFF
--- a/pipe/buffer.go
+++ b/pipe/buffer.go
@@ -91,6 +91,9 @@ func (b *buffer) Write(d []byte) (int, error) {
 
 	n, err := b.buf.Write(d)
 
+	// after write, cancel the deadline to prevent error
+	b.wState.CancelDeadline()
+
 	// signal so if there is any reader waiting, it will rState the data
 	b.cond.Signal()
 	return n, err


### PR DESCRIPTION
The problem that I see is that the state is corrupted after the deadline is reached, even if writing has completed successfully, and can't be used, even if a new deadline is set before writing is attempted again.  I don't believe this is the correct behavior for WriteDeadline.  My fix may not be correct either, but it served my purpose for now, and was quick.